### PR TITLE
feat: Add support of passing Twingate Service Key from a file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,15 @@ term_handler() {
 
 trap 'kill ${!}; term_handler' TERM
 
+if [ -n "$SERVICE_KEY_PATH" ]; then
+    if [ -f "$SERVICE_KEY_PATH" ]; then
+        SERVICE_KEY=$(cat "$SERVICE_KEY_PATH")
+    else
+        echo "ERROR! Service key file '$SERVICE_KEY_PATH' not found, exit..."
+        exit 1
+    fi
+fi
+
 if [ -n "$SERVICE_KEY" ]; then
     echo "$SERVICE_KEY" | twingate setup --headless=-
     echo "Start twingate..."


### PR DESCRIPTION
Hi!
Thank you so much for maintaining this container image. It works great!

In this PR I add a small feature, which gives an alternative way of passing the Service Key: using a file path via `$SERVICE_KEY_PATH` instead of a plaintext value `$SERVICE_KEY`.
That could be useful for the case when the Service Key is passed to the container via the volume mount instead of an env variable.

This change is backward compatible. If `SERVICE_KEY_PATH` env var is not set, the script kepps working as before, expecting `SERVICE_KEY` to be set instead.